### PR TITLE
Corrects some outstanding issues with Tervel

### DIFF
--- a/tervel/containers/wf/vector/array_array.h
+++ b/tervel/containers/wf/vector/array_array.h
@@ -54,7 +54,7 @@ class ArrayArray : public VectorArray<T> {
     if (capacity < 2) {
       capacity = 2;
     }
-    for (int i = 0; i < k_max_array_segments_; i++) {
+    for (size_t i = 0; i < k_max_array_segments_; i++) {
       array_of_arrays_[i].store(nullptr);
     }
     offset_pow_ = tervel::util::round_to_next_power_of_two(capacity);

--- a/tervel/containers/wf/vector/read_op.h
+++ b/tervel/containers/wf/vector/read_op.h
@@ -83,7 +83,7 @@ class ReadOp: public tervel::util::OpRecord {
   Vector<T> *vec_;
   size_t idx_;
   std::atomic<T> value_ {Vector<T>::c_not_value_};
-  static const T c_fail_value_ {static_cast<T>(~0x1L)};
+  static constexpr T c_fail_value_ {reinterpret_cast<T>(~0x1L)};
 };  // class ReadOp
 }  // namespace vector
 }  // namespace wf

--- a/tervel/containers/wf/vector/vector.hpp
+++ b/tervel/containers/wf/vector/vector.hpp
@@ -70,7 +70,7 @@ class Vector {
       return temp;
   };
 
-  const size_t capacity() {
+  size_t capacity() {
     return internal_array.capacity();
   };
 

--- a/tervel/containers/wf/vector/vector.hpp
+++ b/tervel/containers/wf/vector/vector.hpp
@@ -74,7 +74,7 @@ class Vector {
     return internal_array.capacity();
   };
 
-  static constexpr T c_not_value_ {static_cast<T>(0x1L)};
+  static constexpr T c_not_value_ {reinterpret_cast<T>(0x1L)};
 
   int64_t size(int64_t val) {
     int64_t temp = current_size_.fetch_add(val);

--- a/tervel/util/memory/hp/hazard_pointer.h
+++ b/tervel/util/memory/hp/hazard_pointer.h
@@ -82,6 +82,11 @@ class HazardPointer {
         void *expected, HazardPointer * const hazard_pointer =
         tervel::tl_thread_info->get_hazard_pointer());
 
+  static void watch(SlotID slot, Element* descr, HazardPointer * const hazard_pointer =
+        tervel::tl_thread_info->get_hazard_pointer()) {
+      hazard_pointer->watch(slot, reinterpret_cast<void*>(descr));
+  }
+
   /**
    * This method is used to achieve a hazard pointer watch on a memory address.
    *


### PR DESCRIPTION
Adds a new overload to HazardPointer::watch that is needed for an accessor implementation for Tervel's vector. 

Removed more warnings that should close out #2. 

Replaces existing const expressions with constexpr expressions to broaden the amount of types available for use in Tervel, though they must still be able to convert trivally to an integral type.

Note: This does not include the wait-free queue implementation, which is required to build some downstream projects (namely OpenMemDB).
