### PR TITLE
fixed issue where recurive return is set but not cleared. added some …

### DIFF
--- a/tervel/util/recursive_action.h
+++ b/tervel/util/recursive_action.h
@@ -43,15 +43,16 @@ class RecursiveAction {
       #if tervel_track_max_recur_depth_reached  == tervel_track_enable
         TERVEL_METRIC(max_recur_depth_reached)
       #endif
-
-
-      RecursiveAction::recursive_return(true, true);
+      RecursiveAction::set_recursive_return();
     }
     RecursiveAction::recursive_depth(1);
   }
 
   ~RecursiveAction() {
-    RecursiveAction::recursive_depth(-1);
+    size_t d = RecursiveAction::recursive_depth(-1);
+    if (d == 0) {
+      RecursiveAction::clear_recursive_return();
+    }
   }
 
   /**


### PR DESCRIPTION
Fixed an issue where the recursive return action was being set but not cleared.

The fix is done by detecting when the recursive depth == 0 and clearing recursive return indicator. This is safe because it indicates that the thread is back to its originating operation.

I added some comments and moved a bit of repeated code into its own function